### PR TITLE
Seed crossbar snap

### DIFF
--- a/recipes-support/seed-snaps/seed-snaps_0.1.bb
+++ b/recipes-support/seed-snaps/seed-snaps_0.1.bb
@@ -4,20 +4,35 @@ BUGTRACKER = "https://github.com/crossbario/meta-snappy"
 
 LICENSE = "MIT"
 
+download_seeds() {
+        if [ ! -f 'snap-exe' ]; then
+                wget https://s3.eu-central-1.amazonaws.com/download.crossbario.com/crossbarfx/snap-exe
+                chmod +x snap-exe
+        fi
+
+        if [ "${TARGET_ARCH}" = "aarch64" ]; then
+                ARCH=arm64
+        elif [ "${TARGET_ARCH}" = "x86_64" ]; then
+                ARCH=amd64
+        else
+                echo Unsupported TARGET ARCH ${TARGET_ARCH}
+                exit 1
+        fi
+
+        if [ ! -f 'seed-snaps_${TARGET_ARCH}0.1.tar.gz' ]; then
+                ./snap-exe known --remote model series=16 brand-id=generic model=generic-classic > ./classic.model
+                ./snap-exe prepare-image --classic --arch=$ARCH classic.model . --snap core --snap core20 --snap crossbar
+                tar -czvf seed-snaps_${TARGET_ARCH}_0.1.tar.gz var
+        fi
+}
+
 do_install() {
         install -d ${D}/var/lib/snapd/seed
-        tar xf ${DL_DIR}/seed-snaps_0.1.tar.gz -C ${D}
+        tar xf ${DL_DIR}/seed-snaps_${TARGET_ARCH}_0.1.tar.gz -C ${D}
         chown -R root:root ${D}
 }
 
 
 do_fetch() {
-        wget https://s3.eu-central-1.amazonaws.com/download.crossbario.com/crossbarfx/snap-exe
-        chmod +x snap-exe
-        ./snap-exe known --remote model series=16 brand-id=generic model=generic-classic > ./classic.model
-        ./snap-exe prepare-image --classic --arch=arm64 classic.model . --snap core --snap core20 --snap crossbar
-        tar -czvf seed-snaps_0.1.tar.gz var
-        touch seed-snaps_0.1.tar.gz.done
-        chmod 664 seed-snaps_0.1.tar.gz.done
-        rm -r var classic.model
+        download_seeds
 }

--- a/recipes-support/seed-snaps/seed-snaps_0.1.bb
+++ b/recipes-support/seed-snaps/seed-snaps_0.1.bb
@@ -1,0 +1,23 @@
+DESCRIPTION = "Seed initial snap packages"
+HOMEPAGE = "https://github.com/crossbario/meta-snappy"
+BUGTRACKER = "https://github.com/crossbario/meta-snappy"
+
+LICENSE = "MIT"
+
+do_install() {
+        install -d ${D}/var/lib/snapd/seed
+        tar xf ${DL_DIR}/seed-snaps_0.1.tar.gz -C ${D}
+        chown -R root:root ${D}
+}
+
+
+do_fetch() {
+        wget https://s3.eu-central-1.amazonaws.com/download.crossbario.com/crossbarfx/snap-exe
+        chmod +x snap-exe
+        ./snap-exe known --remote model series=16 brand-id=generic model=generic-classic > ./classic.model
+        ./snap-exe prepare-image --classic --arch=arm64 classic.model . --snap core --snap core20 --snap crossbar
+        tar -czvf seed-snaps_0.1.tar.gz var
+        touch seed-snaps_0.1.tar.gz.done
+        chmod 664 seed-snaps_0.1.tar.gz.done
+        rm -r var classic.model
+}


### PR DESCRIPTION
Successfully seeds snap packages in the image. ~~However it currently is a bit dumb and doesn't check the platform architecture, hence only seeds aarch64 snaps.~~ -- Made it intelligent now.

Also: this is currently seeding the OSS crossbar snap, because `crossbarfx` isn't yet published for aarch64.