### PR TITLE
Enable eCryptFS support in the kernel

### DIFF
--- a/recipes-kernel/linux/files/snappy.cfg
+++ b/recipes-kernel/linux/files/snappy.cfg
@@ -135,3 +135,8 @@ CONFIG_DEFAULT_SECURITY="apparmor"
 
 CONFIG_INTEGRITY=y
 CONFIG_INTEGRITY_AUDIT=y
+
+# Required for ecryptfs, maybe move to a separate recipe somewhere
+CONFIG_CRYPTO=y
+CONFIG_ECRYPT_FS=y
+CONFIG_ECRYPT_FS_MESSAGING=y


### PR DESCRIPTION
Needed to enable these flags for `/dev/ecryptfs` to appear.

https://elixir.bootlin.com/linux/latest/source/fs/ecryptfs/Kconfig